### PR TITLE
Add Helm-chart

### DIFF
--- a/deploy/helm/zeebe-dmn-worker/.helmignore
+++ b/deploy/helm/zeebe-dmn-worker/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/zeebe-dmn-worker/Chart.yaml
+++ b/deploy/helm/zeebe-dmn-worker/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: zeebe-dmn-worker
+description: Zeebe worker for DMN decision evaluation
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.5.0

--- a/deploy/helm/zeebe-dmn-worker/templates/_helpers.tpl
+++ b/deploy/helm/zeebe-dmn-worker/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/zeebe-dmn-worker/templates/configmap.yaml
+++ b/deploy/helm/zeebe-dmn-worker/templates/configmap.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+metadata:
+  name: {{ include "chart.fullname" . }}
+apiVersion: v1
+data:
+  application.yml: |
+    {{ tpl .Values.config . | nindent 4 }}

--- a/deploy/helm/zeebe-dmn-worker/templates/deployment.yaml
+++ b/deploy/helm/zeebe-dmn-worker/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    zeebe-gateway-client: "true"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "chart.selectorLabels" . | nindent 8 }}
+        zeebe-gateway-client: "true"
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.command }}
+          command:
+            {{- toYaml .Values.command | nindent 12 }}
+          {{- end }}
+          {{- if .Values.args }}
+          args:
+            {{- toYaml .Values.args | nindent 12 }}
+          {{- end }}
+          env:
+            - name: "zeebe.client.broker.contactPoint"
+              value: {{ tpl .Values.global.zeebe . | quote }}
+            - name: "zeebe.worker.dmn.repository"
+              value: {{ .Values.global.dmnRepostiory | quote }}
+          {{- if .Values.additionalEnv }}
+            {{- toYaml .Values.additionalEnv | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/deploy/helm/zeebe-dmn-worker/templates/deployment.yaml
+++ b/deploy/helm/zeebe-dmn-worker/templates/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ include "chart.fullname" . }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
-    zeebe-gateway-client: "true"
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -14,7 +13,9 @@ spec:
     metadata:
       labels:
         {{- include "chart.selectorLabels" . | nindent 8 }}
-        zeebe-gateway-client: "true"
+      {{- with .Values.additionalLabels }}
+        {{- toYaml . | nindent 8}}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -29,24 +30,42 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.command }}
+          {{- with .Values.command }}
           command:
-            {{- toYaml .Values.command | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.args }}
+          {{- with .Values.args }}
           args:
-            {{- toYaml .Values.args | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.additionalEnv }}
           env:
-            - name: "zeebe.client.broker.contactPoint"
-              value: {{ tpl .Values.global.zeebe . | quote }}
-            - name: "zeebe.worker.dmn.repository"
-              value: {{ .Values.global.dmnRepostiory | quote }}
-          {{- if .Values.additionalEnv }}
-            {{- toYaml .Values.additionalEnv | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{ with .Values.ports }}
+          ports:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{ with .Values.probes }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/resources/application.yml
+              subPath: application.yml
+            {{- with .Values.global.dmnRepository.volumeMount }}
+              {{ toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "chart.fullname" . }}
+            defaultMode: 0744
+        {{- with .Values.global.dmnRepository.volumeClaim }}
+          {{ toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/zeebe-dmn-worker/templates/ingress.yaml
+++ b/deploy/helm/zeebe-dmn-worker/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "chart.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/zeebe-dmn-worker/templates/service.yaml
+++ b/deploy/helm/zeebe-dmn-worker/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  {{ with .Values.service.ports }}
+  ports:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/zeebe-dmn-worker/templates/service.yaml
+++ b/deploy/helm/zeebe-dmn-worker/templates/service.yaml
@@ -1,14 +1,14 @@
+{{- with .Values.ports }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "chart.fullname" . }}
+  name: {{ include "chart.fullname" $ }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "chart.labels" $ | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
-  {{ with .Values.service.ports }}
+  type: {{ $.Values.service.type }}
   ports:
     {{ toYaml . | nindent 4 }}
-  {{- end }}
   selector:
-    {{- include "chart.selectorLabels" . | nindent 4 }}
+    {{- include "chart.selectorLabels" $ | nindent 4 }}
+{{- end }}

--- a/deploy/helm/zeebe-dmn-worker/templates/serviceaccount.yaml
+++ b/deploy/helm/zeebe-dmn-worker/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chart.serviceAccountName" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/deploy/helm/zeebe-dmn-worker/values.yaml
+++ b/deploy/helm/zeebe-dmn-worker/values.yaml
@@ -21,6 +21,51 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+service:
+  type: ClusterIP
+  ports: []
+    # - type: ClusterIP
+    #   port: 80
+    #   targetPort: http
+    #   name: http
+    #   protocol: TCP
+
+ports: []
+  # - name: http
+  #   containerPort: 80
+  #   protocol: TCP
+
+probes: {}
+  # livenessProbe:
+  #   httpGet:
+  #     path: /
+  #     port: http
+  # readinessProbe:
+  #   httpGet:
+  #     path: /
+  #     port: http
+
+command: []
+
+args: []
+
+additionalEnv: []
+
+additionalLabels: []
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 podSecurityContext: {}
   # fsGroup: 2000
 
@@ -51,5 +96,17 @@ tolerations: []
 affinity: {}
 
 global:
-  zeebe: "{{ .Release.Name }}-zeebe-gateway:26500" # the zeebe service instance where operate will connect
-  dmnRepostiory: "/usr/share/zeebe/dmn-repo"
+  dmnRepository:
+    path: "/usr/share/zeebe/dmn-repo"
+    volumeClaim: {}
+    volumeMount: {}
+
+  brokerContactPoint: "zeebe-gateway:26500"
+
+# https://github.com/zeebe-io/zeebe-dmn-worker#configuration
+config: |
+  zeebe:
+    worker:
+      dmn.repository: {{ .Values.global.dmnRepository.path }}
+    client:
+      broker.contactPoint: {{ .Values.global.brokerContactPoint }}

--- a/deploy/helm/zeebe-dmn-worker/values.yaml
+++ b/deploy/helm/zeebe-dmn-worker/values.yaml
@@ -1,0 +1,55 @@
+# Default values for chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: camunda/zeebe-dmn-worker
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+global:
+  zeebe: "{{ .Release.Name }}-zeebe-gateway:26500" # the zeebe service instance where operate will connect
+  dmnRepostiory: "/usr/share/zeebe/dmn-repo"


### PR DESCRIPTION
Hey Folks,

I did my best and created a Helm-chart for the `zeebe-dmn-worker`.  
Since I'm not very familiar with `Java` itself and the possibilities in configuration, I'm very open for any suggestions.

There are also some things I would like to clarify / ask:

* Yet, there are no liveness- or readiness-probes defined, because I don't know if they even exist? Nevertheless, everything is prepared to integrate them very easily (`.Values.probes`)

* Same goes for `ports`. Since I don't know if the `dmn-worker` exposes any `ports` (the `docker-compose.yml` says no), I did not define them. However, they can be set via `.Values.ports`

* Same goes for the `ingress`-ressource. Actually, without `ports` there is neither an `ingress`- nor a `service`-resource.

* It's also a bit tricky to get the `dmn-repository` into the container in a configurable way. I've prepared the possibility to add them via volumeMounts: `.Values.global.dmnRepository.volumeClaim` and `.Values.global.dmnRepository.volumeMount`
  * In our environment we're creating our own `Dockerfile` on top of `camunda/zeebe-dmn-worker` and simply copying the dmn-files directly into the image.
  * It would be great if there were some kind of [operator](https://github.com/operator-framework/operator-sdk) handling these things

Recommendations:
* I'd recommend to add a CI-pipeline for validating the helm chart - this actually saved us from crashing our kubernetes applications many times:
  * `helm template deploy/helm/zeebe-dmn-worker/.`
  * `helm lint deploy/helm/zeebe-dmn-worker/`


Regards! (=